### PR TITLE
Deploy sparkfe java module to central repository

### DIFF
--- a/sparkfe/pom.xml
+++ b/sparkfe/pom.xml
@@ -3,12 +3,38 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com._4paradigm.hybridsql</groupId>
+	<groupId>com.4paradigm.hybridsql</groupId>
 	<artifactId>sparkfe</artifactId>
-	<packaging>jar</packaging>
-	<name>sparkfe</name>
 	<!-- Use the version from different profile -->
 	<version>${projectVersionFromProfile}</version>
+	<packaging>jar</packaging>
+
+	<name>sparkfe</name>
+	<description>The LLVM-based and high-performance Spark native execution engine which is designed for feature engineering.</description>
+	<url>https://github.com/4paradigm/SparkFE</url>
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<id>tobe</id>
+			<name>Toby Chan</name>
+			<email>chendihao@4paradigm.com</email>
+			<url>http://github.com/tobegit3hub</url>
+			<organization>4Paradigm</organization>
+			<organizationUrl>https://www.4paradigm.com/</organizationUrl>
+		</developer>
+	</developers>
+	<scm>
+		<connection>scm:git:https://github.com/4paradigm/SparkFE.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com:4paradigm/SparkFE.git</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/4paradigm/SparkFE</url>
+	</scm>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -512,7 +538,71 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- For deploying in central repository -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.4.2</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.9.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
+
 		<pluginManagement>
 			<plugins>
 				<plugin>
@@ -558,16 +648,16 @@
 
 	<distributionManagement>
 		<snapshotRepository>
-			<id>file-repository</id>
-			<url>file:///tmp/hybridse_java_packages/</url>
+			<id>ossrh</id>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
 		<repository>
-			<id>file-repository</id>
-			<url>file:///tmp/hybridse_java_packages/</url>
+			<id>ossrh</id>
+			<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
 	</distributionManagement>
 
-	<!-- 4paradigm -->
+	<!-- 4paradigm maven repository -->
 	<repositories>
 		<repository>
 			<id>4paradigm-github</id>

--- a/sparkfe/src/main/java/com/_4paradigm/hybridsql/spark/utils/DDLEngine.java
+++ b/sparkfe/src/main/java/com/_4paradigm/hybridsql/spark/utils/DDLEngine.java
@@ -93,9 +93,6 @@ public class DDLEngine {
 
     /**
      *
-     * @param sql
-     * @param schema json format
-     * @return
      */
     public static String genDDL(String sql, String schema) throws Exception {
         String tempDB = "temp_" + System.currentTimeMillis();

--- a/sparkfe/src/main/java/com/_4paradigm/hybridsql/spark/utils/SkewUtils.java
+++ b/sparkfe/src/main/java/com/_4paradigm/hybridsql/spark/utils/SkewUtils.java
@@ -24,9 +24,7 @@ import java.util.Map;
 
 
 /**
- * @Author wangzixian
- * @Description TODO
- * @Date 2020/12/2 19:15
+ *
  **/
 public class SkewUtils {
 
@@ -60,17 +58,6 @@ public class SkewUtils {
 
     /**
      *
-     * @param table1
-     * @param table2
-     * @param quantile
-     * @param schemas
-     * @param keysMap
-     * @param ts
-     * @param tag1 skewTag 标签位
-     * @param tag2 skewPosition
-     * @param tag3 skewCntName
-     * @param tag4 skewCnt = 100
-     * @return
      */
     public static String genPercentileTagSql(String table1, String table2, int quantile, List<String> schemas, Map<String, String> keysMap, String ts, String tag1, String tag2, String tag3, long tag4) {
         StringBuffer sql = new StringBuffer();
@@ -96,12 +83,7 @@ public class SkewUtils {
     }
 
     /**
-     * ?shu
-     * @paraable1
-     * @param ts
-     * @param quantile
-     * @param output
-     * @return
+     *
      */
     public static String caseWhenTag(String table1, String table2, String ts, int quantile, String output, String con1, long cnt) {
         StringBuffer sql = new StringBuffer();


### PR DESCRIPTION
Rename the sparkfe java module for deploying to central repository. Fix the java docs so that we can use Java docs plugin when deploying.

* Resolve https://github.com/4paradigm/SparkFE/issues/44 .
* Resolve https://github.com/4paradigm/SparkFE/issues/55 .
